### PR TITLE
ARC-1969 - Adding jiraHost for fetching logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cookie-parser": "^1.4.6",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
+    "jwt-decode": "^3.1.2",
     "mustache-express": "^1.3.2",
     "nedb": "^1.8.0",
     "tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "tsnd src/server.ts"
   },
   "dependencies": {
+    "atlassian-jwt": "^2.0.2",
     "cookie-parser": "^1.4.6",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "atlassian-jwt": "^2.0.2",
-    "cookie-parser": "^1.4.6",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "mustache-express": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "cookie-parser": "^1.4.6",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "jwt-decode": "^3.1.2",
     "mustache-express": "^1.3.2",
     "nedb": "^1.8.0",
     "tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "mustache-express": "^1.3.2",
-    "nedb": "^1.8.0",
+    "nedb-promises": "^6.2.1",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "tsnd src/server.ts"
   },
   "dependencies": {
+    "cookie-parser": "^1.4.6",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "mustache-express": "^1.3.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import Routes from './routes';
+import cookieParser from 'cookie-parser';
 import mustache from 'mustache-express';
 
 class App {
@@ -20,6 +21,7 @@ class App {
 
     middlewares() {
         this.server.use(express.json());
+        this.server.use(cookieParser());
     }
 
     routes() {
@@ -27,4 +29,4 @@ class App {
     }
 }
 
-export default new App().server
+export default new App().server;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import Routes from './routes';
+import routes from './routes';
 import mustache from 'mustache-express';
 
 const serverApp = express();
@@ -15,6 +15,6 @@ serverApp.set('views', __dirname + '/views');
 serverApp.use(express.json());
 
 // Setting the routes
-serverApp.use(Routes);
+serverApp.use(routes);
 
-export const App = serverApp;
+export const app = serverApp;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import Routes from './routes';
-import cookieParser from 'cookie-parser';
 import mustache from 'mustache-express';
 
 class App {
@@ -21,7 +20,6 @@ class App {
 
     middlewares() {
         this.server.use(express.json());
-        this.server.use(cookieParser());
     }
 
     routes() {

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,29 +2,19 @@ import express from 'express';
 import Routes from './routes';
 import mustache from 'mustache-express';
 
-class App {
-    public server;
+const serverApp = express();
 
-    constructor() {
-        this.server = express();
-        this.setEngine();
-        this.middlewares();
-        this.routes();
-    }
+// Setting the template engine
+serverApp.engine('mst', mustache());
+serverApp.set('view engine', 'mst');
 
-    setEngine() {
-        this.server.engine('mst', mustache());
-        this.server.set('view engine', 'mst');
-        this.server.set('views', __dirname + '/views');
-    }
+// Setting the views
+serverApp.set('views', __dirname + '/views');
 
-    middlewares() {
-        this.server.use(express.json());
-    }
+// Calling the express.json() method for parsing
+serverApp.use(express.json());
 
-    routes() {
-        this.server.use(Routes);
-    }
-}
+// Setting the routes
+serverApp.use(Routes);
 
-export default new App().server;
+export const App = serverApp;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -32,7 +32,7 @@ export const connectAppDescriptor = ({ baseUrl }: ConnectAppDescriptorProps): Co
                 key: 'acn-index',
                 name: {
                     value: 'Index'
-                },
+                }
             },
             webhooks: [
                 {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,30 +7,30 @@ type ConnectJsonObject = { [k: string]: ConnectJsonValue }
 type ConnectJsonArray = ConnectJsonValue[]
 type ConnectJsonValue = ConnectJsonArray | ConnectJsonObject | ConnectJsonPrimitive
 
-export const connectAppDescriptor = ({ baseUrl }: ConnectAppDescriptorProps): ConnectJsonValue => {
+export const connectAppDescriptor = ({baseUrl}: ConnectAppDescriptorProps): ConnectJsonValue => {
     return {
-            name: 'Sample Connect App Node',
-            description: 'Atlassian Connect app - Node',
-            key: 'com.atlassian.sample-app-node',
-            baseUrl,
-            vendor: {
+        name: 'Sample Connect App Node',
+        description: 'Atlassian Connect app - Node',
+        key: 'com.atlassian.sample-app-node',
+        baseUrl,
+        vendor: {
             name: 'Node connect app sample',
             url: 'https://github.com/atlassian/atlassian-connect-sample-app-node/'
         },
         authentication: {
             type: 'jwt'
         },
-        scopes: [ "READ" ],
-            apiVersion: 1,
-            lifecycle: {
+        scopes: ["READ"],
+        apiVersion: 1,
+        lifecycle: {
             installed: '/events/installed',
-                uninstalled: '/events/uninstalled'
+            uninstalled: '/events/uninstalled'
         },
         modules: {
             postInstallPage: {
                 url: '/',
-                    key: 'acn-index',
-                    name: {
+                key: 'acn-index',
+                name: {
                     value: 'Index'
                 },
             },
@@ -48,7 +48,7 @@ export const connectAppDescriptor = ({ baseUrl }: ConnectAppDescriptorProps): Co
                     url: "/webhooks/jira/issue-updated"
                 }
             ],
-                generalPages: [
+            generalPages: [
                 {
                     url: '/config',
                     key: 'acn-config',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -18,7 +18,7 @@ export const connectAppDescriptor = ({ baseUrl }: ConnectAppDescriptorProps): Co
             url: 'https://github.com/atlassian/atlassian-connect-sample-app-node/'
         },
         authentication: {
-            type: 'none'
+            type: 'jwt'
         },
         scopes: [ "READ" ],
         apiVersion: 1,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,11 +9,11 @@ type ConnectJsonValue = ConnectJsonArray | ConnectJsonObject | ConnectJsonPrimit
 
 export const connectAppDescriptor = ({ baseUrl }: ConnectAppDescriptorProps): ConnectJsonValue => {
     return {
-        name: 'Sample Connect App Node',
-        description: 'Atlassian Connect app - Node',
-        key: 'com.atlassian.sample-app-node',
-        baseUrl,
-        vendor: {
+            name: 'Sample Connect App Node',
+            description: 'Atlassian Connect app - Node',
+            key: 'com.atlassian.sample-app-node',
+            baseUrl,
+            vendor: {
             name: 'Node connect app sample',
             url: 'https://github.com/atlassian/atlassian-connect-sample-app-node/'
         },
@@ -21,16 +21,16 @@ export const connectAppDescriptor = ({ baseUrl }: ConnectAppDescriptorProps): Co
             type: 'jwt'
         },
         scopes: [ "READ" ],
-        apiVersion: 1,
-        lifecycle: {
+            apiVersion: 1,
+            lifecycle: {
             installed: '/events/installed',
-            uninstalled: '/events/uninstalled'
+                uninstalled: '/events/uninstalled'
         },
         modules: {
             postInstallPage: {
                 url: '/',
-                key: 'acn-index',
-                name: {
+                    key: 'acn-index',
+                    name: {
                     value: 'Index'
                 },
             },
@@ -48,7 +48,7 @@ export const connectAppDescriptor = ({ baseUrl }: ConnectAppDescriptorProps): Co
                     url: "/webhooks/jira/issue-updated"
                 }
             ],
-            generalPages: [
+                generalPages: [
                 {
                     url: '/config',
                     key: 'acn-config',
@@ -67,5 +67,5 @@ export const connectAppDescriptor = ({ baseUrl }: ConnectAppDescriptorProps): Co
                 }
             ]
         }
-    }
-}
+    };
+};

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -50,11 +50,19 @@ export const connectAppDescriptor = ({ baseUrl }: ConnectAppDescriptorProps): Co
             ],
             generalPages: [
                 {
-                    url: '/',
-                    key: 'acn-contact',
+                    url: '/config',
+                    key: 'acn-config',
                     location: 'none',
                     name: {
-                        'value': 'Index'
+                        'value': 'Connect Descriptor'
+                    }
+                },
+                {
+                    url: '/logs/webhooks',
+                    key: 'acn-logs-webhooks',
+                    location: 'none',
+                    name: {
+                        'value': 'Logs for webhooks'
                     }
                 }
             ]

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,7 +7,7 @@ type ConnectJsonObject = { [k: string]: ConnectJsonValue }
 type ConnectJsonArray = ConnectJsonValue[]
 type ConnectJsonValue = ConnectJsonArray | ConnectJsonObject | ConnectJsonPrimitive
 
-export const connectAppDescriptor = ({baseUrl}: ConnectAppDescriptorProps): ConnectJsonValue => {
+export const connectAppDescriptor = ({ baseUrl }: ConnectAppDescriptorProps): ConnectJsonValue => {
     return {
         name: 'Sample Connect App Node',
         description: 'Atlassian Connect app - Node',
@@ -20,7 +20,7 @@ export const connectAppDescriptor = ({baseUrl}: ConnectAppDescriptorProps): Conn
         authentication: {
             type: 'jwt'
         },
-        scopes: ["READ"],
+        scopes: [ "READ" ],
         apiVersion: 1,
         lifecycle: {
             installed: '/events/installed',

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -8,54 +8,54 @@ export type TenantType = {
 };
 
 export const DBFile = new Datastore({
-    filename: path.join(__dirname, './storage/storageFile.db') ,
+    filename: path.join(__dirname, './storage/storageFile.db'),
     autoload: true
 });
 
-export const findOneInDb = (query: {}, successCallback: Function, failureCallback: Function) => {
+export const findOneInDb = (query: {}) => new Promise((resolve) => {
     DBFile.findOne(query, (error, data) => {
         if (error) {
             console.error("Error when finding: ", error);
-            failureCallback && failureCallback(error);
+            throw new Error(error);
         } else {
             console.log("Found successfully", data);
-            successCallback && successCallback(data);
+            resolve(data);
         }
     });
-};
+});
 
-export const insertToDb = (data: any, successCallback: Function, failureCallback: Function) => {
+export const insertToDb = (data: any) => new Promise((resolve) => {
     DBFile.insert(data, (error, data) => {
         if (error) {
             console.error("Error when inserting: ", error);
-            failureCallback && failureCallback(error);
+            throw new Error(error);
         } else {
             console.log("Inserted successfully", data);
-            successCallback && successCallback(data);
+            resolve(data);
         }
     });
-};
+});
 
-export const updateToDb = (query: {}, newData: any, successCallback: Function, failureCallback: Function) => {
+export const updateToDb = (query: {}, newData: any) => new Promise((resolve) => {
     DBFile.update(query, newData, {}, (error, data) => {
         if (error) {
             console.error("Error when updating: ", error);
-            failureCallback && failureCallback(error);
+            throw new Error(error);
         } else {
             console.log("Updated successfully", data);
-            successCallback && successCallback(data);
+            resolve(data);
         }
     });
-};
+});
 
-export const removeFromDB = (query: {}, successCallback: Function, failureCallback: Function) => {
+export const removeFromDB = (query: {}) => new Promise((resolve) => {
     DBFile.remove(query, (error, data) => {
         if (error) {
             console.error("Error when removing: ", error);
-            failureCallback && failureCallback(error);
+            throw new Error(error);
         } else {
             console.log("Removed successfully", data);
-            successCallback && successCallback(data);
+            resolve(data);
         }
     });
-};
+});

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 export type TenantType = {
     host: string;
+    sharedSecret: string;
     clientKey: string;
     logs: Array<string>
 };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,62 +1,51 @@
-import Datastore from 'nedb';
+import Datastore from 'nedb-promises';
 import path from 'path';
 
 export type TenantType = {
+    _id: string | null;
     host: string;
     sharedSecret: string;
     clientKey: string;
     logs: Array<string>
 };
 
-export const DBFile = new Datastore({
+export const DBFile = Datastore.create({
     filename: path.join(__dirname, './storage/storageFile.db'),
     autoload: true
 });
 
-export const findOneInDb = (query: {}) => new Promise((resolve) => {
-    DBFile.findOne(query, (error, data) => {
-        if (error) {
-            console.error("Error when finding: ", error);
-            throw new Error(error);
-        } else {
-            console.log("Found successfully", data);
-            resolve(data);
-        }
+export const findOneInDb = async (query: {}) => DBFile.findOne(query)
+    .then(data => {
+        console.log("Found successfully", data);
+        return data;
+    }).catch((error) => {
+        console.error("Error when finding: ", error);
+        throw new Error(error);
     });
-});
 
-export const insertToDb = (data: any) => new Promise((resolve) => {
-    DBFile.insert(data, (error, data) => {
-        if (error) {
-            console.error("Error when inserting: ", error);
-            throw new Error(error);
-        } else {
-            console.log("Inserted successfully", data);
-            resolve(data);
-        }
+export const insertToDb = async (data: any) => DBFile.insert(data)
+    .then(data => {
+        console.log("Inserted successfully", data);
+        return data;
+    }).catch((error) => {
+        console.error("Error when inserting: ", error);
+        throw new Error(error);
     });
-});
 
-export const updateToDb = (query: {}, newData: any) => new Promise((resolve) => {
-    DBFile.update(query, newData, {}, (error, data) => {
-        if (error) {
-            console.error("Error when updating: ", error);
-            throw new Error(error);
-        } else {
-            console.log("Updated successfully", data);
-            resolve(data);
-        }
+export const updateToDb = async (query: {}, newData: any) => DBFile.update(query, newData, {})
+    .then(data => {
+        console.log("Updated successfully", data);
+        return data;
+    }).catch((error) => {
+        console.error("Error when updating: ", error);
+        throw new Error(error);
     });
-});
 
-export const removeFromDB = (query: {}) => new Promise((resolve) => {
-    DBFile.remove(query, (error, data) => {
-        if (error) {
-            console.error("Error when removing: ", error);
-            throw new Error(error);
-        } else {
-            console.log("Removed successfully", data);
-            resolve(data);
-        }
+export const removeFromDB = async (query: {}) => DBFile.remove(query, {})
+    .then(data => {
+        console.log("Removed successfully", data);
+        return data;
+    }).catch((error) => {
+        console.error("Error when removing: ", error);
+        throw new Error(error);
     });
-});

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 export type TenantType = {
     host: string;
+    clientKey: string;
     logs: Array<string>
 };
 

--- a/src/middlewares/jwtMiddleware.ts
+++ b/src/middlewares/jwtMiddleware.ts
@@ -1,28 +1,15 @@
-/**
- * These options are required for allowing the app which is inside the iframe to set cookies
- */
-const cookieOptions =  {
-    sameSite: "none",
-    secure: true,
-    httpOnly: true
-};
+import { decodeJwtToken } from '../utils';
 
 /**
- * This middleware saves the JWT token from Jira into the browser cookies
+ * This middleware decodes the JWT token from Jira and identifies the users
  */
 export const jwtTokenMiddleware = (req, res, next) => {
-    // Check the cookies first
-    if (req.cookies.jwt) {
-        res.locals.jwt = req.cookies.jwt;
-    } else {
-        // Check if its in query parameters
-        if (req.query.jwt) {
-            res.cookie('jwt', req.query.jwt, cookieOptions);
-            res.locals.jwt = req.query.jwt;
-        } else {
-            res.locals.jwt = undefined;
-        }
+    if (!req.query.jwt) {
+        console.error('JWT Token not found!');
+        throw new Error('JWT Token not found!');
     }
 
+    const decodedJwtToken = decodeJwtToken(req.query.jwt);
+    res.locals.clientKey = decodedJwtToken.iss;
     next();
 };

--- a/src/middlewares/jwtMiddleware.ts
+++ b/src/middlewares/jwtMiddleware.ts
@@ -4,6 +4,9 @@ const cookieOptions =  {
     httpOnly: true
 };
 
+/**
+ * This middleware saves the JWT token from Jira into the browser cookies
+ */
 export const jwtTokenMiddleware = (req, res, next) => {
     // Check the cookies first
     if (req.cookies.jwt) {

--- a/src/middlewares/jwtMiddleware.ts
+++ b/src/middlewares/jwtMiddleware.ts
@@ -1,0 +1,22 @@
+const cookieOptions =  {
+    sameSite: "none",
+    secure: true,
+    httpOnly: true
+};
+
+export const jwtTokenMiddleware = (req, res, next) => {
+    // Check the cookies first
+    if (req.cookies.jwt) {
+        res.locals.jwt = req.cookies.jwt;
+    } else {
+        // Check if its in query parameters
+        if (req.query.jwt) {
+            res.cookie('jwt', req.query.jwt, cookieOptions);
+            res.locals.jwt = req.query.jwt;
+        } else {
+            res.locals.jwt = undefined;
+        }
+    }
+
+    next();
+};

--- a/src/middlewares/jwtMiddleware.ts
+++ b/src/middlewares/jwtMiddleware.ts
@@ -1,5 +1,5 @@
 import { decodeJwtToken } from '../utils';
-import {findOneInDb, TenantType} from '../db';
+import { findOneInDb, TenantType } from '../db';
 
 /**
  * This middleware decodes the JWT token from Jira and identifies the users

--- a/src/middlewares/jwtMiddleware.ts
+++ b/src/middlewares/jwtMiddleware.ts
@@ -1,17 +1,25 @@
-import {decodeAtlassianJwtToken, decodeJwtToken} from '../utils';
+import { decodeJwtToken } from '../utils';
+import {findOneInDb, TenantType} from '../db';
 
 /**
  * This middleware decodes the JWT token from Jira and identifies the users
  */
-export const jwtTokenMiddleware = (req, res, next) => {
+export const jwtTokenMiddleware = async (req, res, next) => {
     if (!req.query.jwt) {
         console.error('JWT Token not found!');
         throw new Error('JWT Token not found!');
     }
 
-    const decodedJwtToken = decodeJwtToken(req.query.jwt);
+    const host = req.query.xdm_e;
+    const tenant = await findOneInDb(
+        { host },
+    ) as TenantType;
 
-    res.locals.atlassianToken = decodeAtlassianJwtToken(req.query.jwt);
-    res.locals.clientKey = decodedJwtToken.iss;
+    if (tenant?.sharedSecret) {
+        const decodedJwtToken = decodeJwtToken(req.query.jwt, tenant.sharedSecret);
+
+        res.locals.clientKey = decodedJwtToken.iss;
+    }
+
     next();
 };

--- a/src/middlewares/jwtMiddleware.ts
+++ b/src/middlewares/jwtMiddleware.ts
@@ -1,4 +1,4 @@
-import { decodeJwtToken } from '../utils';
+import {decodeAtlassianJwtToken, decodeJwtToken} from '../utils';
 
 /**
  * This middleware decodes the JWT token from Jira and identifies the users
@@ -10,6 +10,8 @@ export const jwtTokenMiddleware = (req, res, next) => {
     }
 
     const decodedJwtToken = decodeJwtToken(req.query.jwt);
+
+    res.locals.atlassianToken = decodeAtlassianJwtToken(req.query.jwt);
     res.locals.clientKey = decodedJwtToken.iss;
     next();
 };

--- a/src/middlewares/jwtMiddleware.ts
+++ b/src/middlewares/jwtMiddleware.ts
@@ -1,3 +1,6 @@
+/**
+ * These options are required for allowing the app which is inside the iframe to set cookies
+ */
 const cookieOptions =  {
     sameSite: "none",
     secure: true,

--- a/src/routes/atlassian-connect.ts
+++ b/src/routes/atlassian-connect.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { connectAppDescriptor } from "../config";
 import { baseUrl } from "../utils";
 
-export const ConnectDescriptorGet = async (_: Request, res: Response): Promise<void> => {
+export const connectDescriptorGet = async (_: Request, res: Response): Promise<void> => {
     const appUrl = { baseUrl: await baseUrl() };
     res.status(200).json(connectAppDescriptor(appUrl));
 };

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -4,8 +4,8 @@ import { insertToDb, removeFromDB, TenantType} from '../db';
 export const EventsRouter = Router();
 
 EventsRouter.post('/installed', (req, res) => {
-    const { baseUrl: host } = req.body;
-    const newTenant: TenantType = { host, logs: [] };
+    const { baseUrl: host, clientKey } = req.body;
+    const newTenant: TenantType = { host, clientKey, logs: [] };
 
     insertToDb(
         newTenant,
@@ -15,10 +15,10 @@ EventsRouter.post('/installed', (req, res) => {
 });
 
 EventsRouter.post('/uninstalled', (req, res) => {
-    const { baseUrl: host } = req.body;
+    const { baseUrl: host, clientKey } = req.body;
 
     removeFromDB(
-        { host },
+        { host, clientKey },
         () => { res.sendStatus(200) },
         (error) => { res.sendStatus(500).json(error) }
     );

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -1,12 +1,11 @@
 import { Router } from 'express';
-import { insertToDb, removeFromDB, TenantType } from '../db';
+import { insertToDb, removeFromDB } from '../db';
 
 export const EventsRouter = Router();
 
 EventsRouter.post('/installed', async (req, res) => {
     const { baseUrl: host, clientKey, sharedSecret } = req.body;
-    const newTenant: TenantType = { host, clientKey, sharedSecret, logs: [] };
-    const insertedData = await insertToDb(newTenant);
+    const insertedData = await insertToDb({ host, clientKey, sharedSecret, logs: [] });
     if (insertedData) {
         res.sendStatus(204);
     } else {

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -5,20 +5,12 @@ export const EventsRouter = Router();
 
 EventsRouter.post('/installed', async (req, res) => {
     const { baseUrl: host, clientKey, sharedSecret } = req.body;
-    const insertedData = await insertToDb({ host, clientKey, sharedSecret, logs: [] });
-    if (insertedData) {
-        res.sendStatus(204);
-    } else {
-        res.sendStatus(500);
-    }
+    await insertToDb({ host, clientKey, sharedSecret, logs: [] });
+    res.sendStatus(204);
 });
 
 EventsRouter.post('/uninstalled', async (req, res) => {
     const { baseUrl: host, clientKey } = req.body;
-    const removedData = await removeFromDB({ host, clientKey });
-    if (removedData) {
-        res.sendStatus(204);
-    } else {
-        res.sendStatus(500);
-    }
+    await removeFromDB({ host, clientKey });
+    res.sendStatus(204);
 });

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -1,15 +1,15 @@
 import { Router } from 'express';
 import { insertToDb, removeFromDB } from '../db';
 
-export const EventsRouter = Router();
+export const eventsRouter = Router();
 
-EventsRouter.post('/installed', async (req, res) => {
+eventsRouter.post('/installed', async (req, res) => {
     const { baseUrl: host, clientKey, sharedSecret } = req.body;
     await insertToDb({ host, clientKey, sharedSecret, logs: [] });
     res.sendStatus(204);
 });
 
-EventsRouter.post('/uninstalled', async (req, res) => {
+eventsRouter.post('/uninstalled', async (req, res) => {
     const { baseUrl: host, clientKey } = req.body;
     await removeFromDB({ host, clientKey });
     res.sendStatus(204);

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -4,8 +4,8 @@ import { insertToDb, removeFromDB, TenantType } from '../db';
 export const EventsRouter = Router();
 
 EventsRouter.post('/installed', async (req, res) => {
-    const { baseUrl: host, clientKey } = req.body;
-    const newTenant: TenantType = { host, clientKey, logs: [] };
+    const { baseUrl: host, clientKey, sharedSecret } = req.body;
+    const newTenant: TenantType = { host, clientKey, sharedSecret, logs: [] };
     const insertedData = await insertToDb(newTenant);
     if (insertedData) {
         res.sendStatus(204);

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -1,25 +1,25 @@
 import { Router } from 'express';
-import { insertToDb, removeFromDB, TenantType} from '../db';
+import { insertToDb, removeFromDB, TenantType } from '../db';
 
 export const EventsRouter = Router();
 
-EventsRouter.post('/installed', (req, res) => {
+EventsRouter.post('/installed', async (req, res) => {
     const { baseUrl: host, clientKey } = req.body;
     const newTenant: TenantType = { host, clientKey, logs: [] };
-
-    insertToDb(
-        newTenant,
-        () => { res.sendStatus(200) },
-        (error) => { res.sendStatus(500).json(error) }
-    );
+    const insertedData = await insertToDb(newTenant);
+    if (insertedData) {
+        res.sendStatus(204);
+    } else {
+        res.sendStatus(500);
+    }
 });
 
-EventsRouter.post('/uninstalled', (req, res) => {
+EventsRouter.post('/uninstalled', async (req, res) => {
     const { baseUrl: host, clientKey } = req.body;
-
-    removeFromDB(
-        { host, clientKey },
-        () => { res.sendStatus(200) },
-        (error) => { res.sendStatus(500).json(error) }
-    );
+    const removedData = await removeFromDB({ host, clientKey });
+    if (removedData) {
+        res.sendStatus(204);
+    } else {
+        res.sendStatus(500);
+    }
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -18,14 +18,14 @@ Routes.use('/public', PublicRouter);
 
 Routes.use('/webhooks', WebhooksRouter);
 
-Routes.get('/', jwtTokenMiddleware, (_req, res) => {
+Routes.get('/', (_req, res) => {
     res.render('index.mst', {
         index: 'Index Page',
         body: 'You in the home page!'
     });
 });
 
-Routes.get('/config', jwtTokenMiddleware, async (_req, res) => {
+Routes.get('/config', async (_req, res) => {
     const props = { baseUrl: await baseUrl() };
     res.render('config.mst', {
         index: 'Connect app descriptor',

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -10,6 +10,13 @@ import { jwtTokenMiddleware } from '../middlewares/jwtMiddleware';
 
 const Routes = Router();
 
+Routes.get('/', (_req, res) => {
+    res.render('index.mst', {
+        index: 'Index Page',
+        body: 'You in the home page!'
+    });
+});
+
 Routes.get('/atlassian-connect.json', ConnectDescriptorGet);
 
 Routes.use('/events', EventsRouter);
@@ -17,13 +24,6 @@ Routes.use('/events', EventsRouter);
 Routes.use('/public', PublicRouter);
 
 Routes.use('/webhooks', WebhooksRouter);
-
-Routes.get('/', (_req, res) => {
-    res.render('index.mst', {
-        index: 'Index Page',
-        body: 'You in the home page!'
-    });
-});
 
 Routes.get('/config', async (_req, res) => {
     const props = { baseUrl: await baseUrl() };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,19 +5,24 @@ import { PublicRouter } from './public';
 import { WebhooksRouter } from './webhooks';
 import { connectAppDescriptor } from '../config';
 import { baseUrl } from '../utils';
+import { jwtTokenMiddleware } from '../middlewares/jwtMiddleware';
 
 const Routes = Router();
 
 Routes.get('/atlassian-connect.json', ConnectDescriptorGet);
 
-Routes.get('/', (_req, res) => {
+Routes.use('/events', EventsRouter);
+
+Routes.use('/public', PublicRouter);
+
+Routes.get('/', jwtTokenMiddleware, (_req, res) => {
     res.render('index.mst', {
         index: 'Index Page',
         body: 'You in the home page!'
     });
 });
 
-Routes.get('/config', async (_req, res) => {
+Routes.get('/config', jwtTokenMiddleware, async (_req, res) => {
     const props = { baseUrl: await baseUrl() };
     res.render('config.mst', {
         index: 'Connect app descriptor',
@@ -25,10 +30,6 @@ Routes.get('/config', async (_req, res) => {
     });
 });
 
-Routes.use('/events', EventsRouter);
-
-Routes.use('/public', PublicRouter);
-
-Routes.use('/webhooks', WebhooksRouter);
+Routes.use('/webhooks', jwtTokenMiddleware, WebhooksRouter);
 
 export default Routes;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,31 +1,31 @@
 import { Router } from 'express';
-import { ConnectDescriptorGet } from './atlassian-connect';
-import { EventsRouter } from './events';
-import { LogsRouter } from './logs';
-import { PublicRouter } from './public';
-import { WebhooksRouter } from './webhooks';
+import { connectDescriptorGet } from './atlassian-connect';
+import { eventsRouter } from './events';
+import { logsRouter } from './logs';
+import { publicRouter } from './public';
+import { webhooksRouter } from './webhooks';
 import { connectAppDescriptor } from '../config';
 import { baseUrl } from '../utils';
 import { jwtTokenMiddleware } from '../middlewares/jwtMiddleware';
 
-const Routes = Router();
+const routes = Router();
 
-Routes.get('/', (_req, res) => {
+routes.get('/', (_req, res) => {
     res.render('index.mst', {
         index: 'Index Page',
         body: 'You in the home page!'
     });
 });
 
-Routes.get('/atlassian-connect.json', ConnectDescriptorGet);
+routes.get('/atlassian-connect.json', connectDescriptorGet);
 
-Routes.use('/events', EventsRouter);
+routes.use('/events', eventsRouter);
 
-Routes.use('/public', PublicRouter);
+routes.use('/public', publicRouter);
 
-Routes.use('/webhooks', WebhooksRouter);
+routes.use('/webhooks', webhooksRouter);
 
-Routes.get('/config', async (_req, res) => {
+routes.get('/config', async (_req, res) => {
     const props = { baseUrl: await baseUrl() };
     res.render('config.mst', {
         index: 'Connect app descriptor',
@@ -33,7 +33,6 @@ Routes.get('/config', async (_req, res) => {
     });
 });
 
-Routes.use('/logs', jwtTokenMiddleware, LogsRouter);
+routes.use('/logs', jwtTokenMiddleware, logsRouter);
 
-
-export default Routes;
+export default routes;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { ConnectDescriptorGet } from './atlassian-connect';
 import { EventsRouter } from './events';
+import { LogsRouter } from './logs';
 import { PublicRouter } from './public';
 import { WebhooksRouter } from './webhooks';
 import { connectAppDescriptor } from '../config';
@@ -14,6 +15,8 @@ Routes.get('/atlassian-connect.json', ConnectDescriptorGet);
 Routes.use('/events', EventsRouter);
 
 Routes.use('/public', PublicRouter);
+
+Routes.use('/webhooks', WebhooksRouter);
 
 Routes.get('/', jwtTokenMiddleware, (_req, res) => {
     res.render('index.mst', {
@@ -30,6 +33,7 @@ Routes.get('/config', jwtTokenMiddleware, async (_req, res) => {
     });
 });
 
-Routes.use('/webhooks', jwtTokenMiddleware, WebhooksRouter);
+Routes.use('/logs', jwtTokenMiddleware, LogsRouter);
+
 
 export default Routes;

--- a/src/routes/logs.ts
+++ b/src/routes/logs.ts
@@ -1,29 +1,23 @@
 import { Router } from 'express';
-import { findOneInDb } from '../db';
+import { findOneInDb, TenantType } from '../db';
+
 export const LogsRouter = Router();
 
-LogsRouter.get('/webhooks', (_req, res) => {
+LogsRouter.get('/webhooks', async (_req, res) => {
     const { clientKey } = res.locals;
-    findOneInDb(
+    const logsData = await findOneInDb(
         { clientKey },
-        (data) => {
-            if (data?.logs.length) {
-                res.render('webhooksLogs.mst', {
-                    index: 'Webhooks Page',
-                    logs: data.logs.sort().reverse()
-                });
-            } else {
-                res.render('webhooksLogs.mst', {
-                    index: 'Webhooks Page',
-                    logs: [ "No logs yet!" ]
-                });
-            }
-        },
-        () => {
-            res.render('webhooksLogs.mst', {
-                index: 'Webhooks Page',
-                logs: [ "No logs yet!" ]
-            });
-        }
-    );
+    ) as TenantType;
+
+    if (logsData?.logs.length) {
+        res.render('webhooksLogs.mst', {
+            index: 'Webhooks Page',
+            logs: logsData.logs.sort().reverse()
+        });
+    } else {
+        res.render('webhooksLogs.mst', {
+            index: 'Webhooks Page',
+            logs: ["No logs yet!"]
+        });
+    }
 });

--- a/src/routes/logs.ts
+++ b/src/routes/logs.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express';
 import { findOneInDb, TenantType } from '../db';
 
-export const LogsRouter = Router();
+export const logsRouter = Router();
 
-LogsRouter.get('/webhooks', async (_req, res) => {
+logsRouter.get('/webhooks', async (_req, res) => {
     const { clientKey } = res.locals;
     const logsData = await findOneInDb(
         { clientKey },

--- a/src/routes/logs.ts
+++ b/src/routes/logs.ts
@@ -9,15 +9,8 @@ LogsRouter.get('/webhooks', async (_req, res) => {
         { clientKey },
     ) as TenantType;
 
-    if (clientKey && logsData?.logs.length) {
-        res.render('webhooksLogs.mst', {
-            index: 'Webhooks Page',
-            logs: logsData.logs.sort().reverse()
-        });
-    } else {
-        res.render('webhooksLogs.mst', {
-            index: 'Webhooks Page',
-            logs: ["No logs yet!"]
-        });
-    }
+    res.render('webhooksLogs.mst', {
+        index: 'Webhooks Page',
+        logs: logsData.logs.sort().reverse()
+    });
 });

--- a/src/routes/logs.ts
+++ b/src/routes/logs.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import { findOneInDb } from '../db';
+export const LogsRouter = Router();
+
+LogsRouter.get('/webhooks', (_req, res) => {
+    const { clientKey } = res.locals;
+    findOneInDb(
+        { clientKey },
+        (data) => {
+            if (data?.logs.length) {
+                res.render('webhooksLogs.mst', {
+                    index: 'Webhooks Page',
+                    logs: data.logs.sort().reverse()
+                });
+            } else {
+                res.render('webhooksLogs.mst', {
+                    index: 'Webhooks Page',
+                    logs: [ "No logs yet!" ]
+                });
+            }
+        },
+        () => {
+            res.render('webhooksLogs.mst', {
+                index: 'Webhooks Page',
+                logs: [ "No logs yet!" ]
+            });
+        }
+    );
+});

--- a/src/routes/logs.ts
+++ b/src/routes/logs.ts
@@ -11,6 +11,6 @@ LogsRouter.get('/webhooks', async (_req, res) => {
 
     res.render('webhooksLogs.mst', {
         index: 'Webhooks Page',
-        logs: logsData.logs.sort().reverse()
+        logs: logsData ? logsData.logs.sort().reverse() : []
     });
 });

--- a/src/routes/logs.ts
+++ b/src/routes/logs.ts
@@ -9,7 +9,7 @@ LogsRouter.get('/webhooks', async (_req, res) => {
         { clientKey },
     ) as TenantType;
 
-    if (logsData?.logs.length) {
+    if (clientKey && logsData?.logs.length) {
         res.render('webhooksLogs.mst', {
             index: 'Webhooks Page',
             logs: logsData.logs.sort().reverse()

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -1,6 +1,6 @@
 import { Router, static as Static } from 'express';
 import path from 'path';
 
-export const PublicRouter = Router();
+export const publicRouter = Router();
 
-PublicRouter.use("/", Static(path.join( process.cwd(), "static")));
+publicRouter.use('/', Static(path.join( process.cwd(), 'static')));

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express';
 import { updateToDb } from '../db';
 
-export const WebhooksRouter = Router();
+export const webhooksRouter = Router();
 
-WebhooksRouter.post('/jira/issue-created', async (req, res) => {
+webhooksRouter.post('/jira/issue-created', async (req, res) => {
     // Mapping the host set during the installation with the url coming in from the webhooks
     const host = new URL(req.body.user.self).origin;
     const updatedData = await updateToDb(
@@ -13,7 +13,7 @@ WebhooksRouter.post('/jira/issue-created', async (req, res) => {
     res.sendStatus(updatedData ? 200 : 500);
 });
 
-WebhooksRouter.post('/jira/issue-updated', async (req, res) => {
+webhooksRouter.post('/jira/issue-updated', async (req, res) => {
     // Mapping the host set during the installation with the url coming in from the webhooks
     const host = new URL(req.body.user.self).origin;
     const updatedData = await updateToDb(
@@ -23,7 +23,7 @@ WebhooksRouter.post('/jira/issue-updated', async (req, res) => {
     res.sendStatus(updatedData ? 200 : 500);
 });
 
-WebhooksRouter.post('/jira/issue-deleted', async (req, res) => {
+webhooksRouter.post('/jira/issue-deleted', async (req, res) => {
     // Mapping the host set during the installation with the url coming in from the webhooks
     const host = new URL(req.body.user.self).origin;
     const updatedData = await updateToDb(

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,43 +1,7 @@
 import { Router } from 'express';
-import { findOneInDb, updateToDb} from '../db';
-import {decodeJwtToken} from '../utils';
+import { updateToDb} from '../db';
 
 export const WebhooksRouter = Router();
-
-WebhooksRouter.get('/', (_req, res) => {
-    const decodedTokenValues = decodeJwtToken(res.locals.jwt);
-    if (decodedTokenValues && decodedTokenValues.iss) {
-        const clientKey = decodedTokenValues.iss;
-
-        findOneInDb(
-            { clientKey },
-            (data) => {
-                if (data?.logs.length) {
-                    res.render('webhooks.mst', {
-                        index: 'Webhooks Page',
-                        logs: data.logs.sort().reverse()
-                    });
-                } else {
-                    res.render('webhooks.mst', {
-                        index: 'Webhooks Page',
-                        logs: [ "No logs yet!" ]
-                    });
-                }
-            },
-            () => {
-                res.render('webhooks.mst', {
-                    index: 'Webhooks Page',
-                    logs: [ "No logs yet!" ]
-                });
-            }
-        );
-    } else {
-        res.render('webhooks.mst', {
-            index: 'Webhooks Page',
-            logs: [ "No logs yet!" ]
-        });
-    }
-});
 
 WebhooksRouter.post('/jira/issue-created', (req, res) => {
     // Mapping the host set during the installation with the url coming in from the webhooks

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -3,39 +3,45 @@ import { updateToDb } from '../db';
 
 export const WebhooksRouter = Router();
 
-WebhooksRouter.post('/jira/issue-created', (req, res) => {
+WebhooksRouter.post('/jira/issue-created', async (req, res) => {
     // Mapping the host set during the installation with the url coming in from the webhooks
     const host = new URL(req.body.user.self).origin;
-
-    updateToDb(
+    const updatedData = await updateToDb(
         { host },
-        { $push: { logs: `${new Date().toISOString()} : Issue created ---> ${JSON.stringify(req.body)}` } },
-        () => { res.sendStatus(200) },
-        (error) => { res.status(500).json(error) },
+        { $push: { logs: `${new Date().toISOString()} : Issue created ---> ${JSON.stringify(req.body)}` } }
     );
+    if (updatedData) {
+        res.sendStatus(200);
+    } else {
+        res.status(500);
+    }
 });
 
-WebhooksRouter.post('/jira/issue-updated', (req, res) => {
+WebhooksRouter.post('/jira/issue-updated', async (req, res) => {
     // Mapping the host set during the installation with the url coming in from the webhooks
     const host = new URL(req.body.user.self).origin;
-
-    updateToDb(
+    const updatedData = await updateToDb(
         { host },
-        { $push: { logs: `${new Date().toISOString()} : Issue updated ---> ${JSON.stringify(req.body)}` } },
-        () => { res.sendStatus(200) },
-        (error) => { res.status(500).json(error) },
+        { $push: { logs: `${new Date().toISOString()} : Issue updated ---> ${JSON.stringify(req.body)}` } }
     );
+    if (updatedData) {
+        res.sendStatus(200);
+    } else {
+        res.status(500);
+    }
 });
 
-WebhooksRouter.post('/jira/issue-deleted', (req, res) => {
+WebhooksRouter.post('/jira/issue-deleted', async (req, res) => {
     // Mapping the host set during the installation with the url coming in from the webhooks
     const host = new URL(req.body.user.self).origin;
-
-    updateToDb(
+    const updatedData = await updateToDb(
         { host },
-        { $push: { logs: `${new Date().toISOString()} : Issue deleted ---> ${JSON.stringify(req.body)}` } },
-        () => { res.sendStatus(200) },
-        (error) => { res.status(500).json(error) },
+        { $push: { logs: `${new Date().toISOString()} : Issue deleted ---> ${JSON.stringify(req.body)}` } }
     );
+    if (updatedData) {
+        res.sendStatus(200);
+    } else {
+        res.status(500);
+    }
 });
 

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -10,11 +10,7 @@ WebhooksRouter.post('/jira/issue-created', async (req, res) => {
         { host },
         { $push: { logs: `${new Date().toISOString()} : Issue created ---> ${JSON.stringify(req.body)}` } }
     );
-    if (updatedData) {
-        res.sendStatus(200);
-    } else {
-        res.sendStatus(500);
-    }
+    res.sendStatus(updatedData ? 200 : 500);
 });
 
 WebhooksRouter.post('/jira/issue-updated', async (req, res) => {
@@ -24,11 +20,7 @@ WebhooksRouter.post('/jira/issue-updated', async (req, res) => {
         { host },
         { $push: { logs: `${new Date().toISOString()} : Issue updated ---> ${JSON.stringify(req.body)}` } }
     );
-    if (updatedData) {
-        res.sendStatus(200);
-    } else {
-        res.sendStatus(500);
-    }
+    res.sendStatus(updatedData ? 200 : 500);
 });
 
 WebhooksRouter.post('/jira/issue-deleted', async (req, res) => {
@@ -38,10 +30,6 @@ WebhooksRouter.post('/jira/issue-deleted', async (req, res) => {
         { host },
         { $push: { logs: `${new Date().toISOString()} : Issue deleted ---> ${JSON.stringify(req.body)}` } }
     );
-    if (updatedData) {
-        res.sendStatus(200);
-    } else {
-        res.sendStatus(500);
-    }
+    res.sendStatus(updatedData ? 200 : 500);
 });
 

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -12,7 +12,7 @@ WebhooksRouter.get('/', (_req, res) => {
         findOneInDb(
             { clientKey },
             (data) => {
-                if (data && data.logs.length) {
+                if (data?.logs.length) {
                     res.render('webhooks.mst', {
                         index: 'Webhooks Page',
                         logs: data.logs.sort().reverse()

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { updateToDb} from '../db';
+import { updateToDb } from '../db';
 
 export const WebhooksRouter = Router();
 

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,36 +1,42 @@
 import { Router } from 'express';
 import { findOneInDb, updateToDb} from '../db';
+import {decodeJwtToken} from '../utils';
 
 export const WebhooksRouter = Router();
 
 WebhooksRouter.get('/', (_req, res) => {
-    // TODO: Decode the jwt from res.locals to get clientKey
-    const clientKey = '5da2d1af-84e0-3d92-bd5d-e26d898fe33c';
+    const decodedTokenValues = decodeJwtToken(res.locals.jwt);
+    if (decodedTokenValues && decodedTokenValues.iss) {
+        const clientKey = decodedTokenValues.iss;
 
-    console.log("webhooks page: ", res.locals);
-
-    findOneInDb(
-        { clientKey },
-        (data) => {
-            if (data && data.logs.length) {
-                res.render('webhooks.mst', {
-                    index: 'Webhooks Page',
-                    logs: data.logs.sort().reverse()
-                });
-            } else {
+        findOneInDb(
+            { clientKey },
+            (data) => {
+                if (data && data.logs.length) {
+                    res.render('webhooks.mst', {
+                        index: 'Webhooks Page',
+                        logs: data.logs.sort().reverse()
+                    });
+                } else {
+                    res.render('webhooks.mst', {
+                        index: 'Webhooks Page',
+                        logs: [ "No logs yet!" ]
+                    });
+                }
+            },
+            () => {
                 res.render('webhooks.mst', {
                     index: 'Webhooks Page',
                     logs: [ "No logs yet!" ]
                 });
             }
-        },
-        () => {
-            res.render('webhooks.mst', {
-                index: 'Webhooks Page',
-                logs: [ "No logs yet!" ]
-            });
-        }
-    );
+        );
+    } else {
+        res.render('webhooks.mst', {
+            index: 'Webhooks Page',
+            logs: [ "No logs yet!" ]
+        });
+    }
 });
 
 WebhooksRouter.post('/jira/issue-created', (req, res) => {

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -3,12 +3,14 @@ import { findOneInDb, updateToDb} from '../db';
 
 export const WebhooksRouter = Router();
 
-WebhooksRouter.get('/', (_, res) => {
-    // TODO: Figure out a way to get the host
-    const host = 'https://kmaharjan4.atlassian.net';
+WebhooksRouter.get('/', (_req, res) => {
+    // TODO: Decode the jwt from res.locals to get clientKey
+    const clientKey = '5da2d1af-84e0-3d92-bd5d-e26d898fe33c';
+
+    console.log("webhooks page: ", res.locals);
 
     findOneInDb(
-        { host },
+        { clientKey },
         (data) => {
             if (data && data.logs.length) {
                 res.render('webhooks.mst', {

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -13,7 +13,7 @@ WebhooksRouter.post('/jira/issue-created', async (req, res) => {
     if (updatedData) {
         res.sendStatus(200);
     } else {
-        res.status(500);
+        res.sendStatus(500);
     }
 });
 
@@ -27,7 +27,7 @@ WebhooksRouter.post('/jira/issue-updated', async (req, res) => {
     if (updatedData) {
         res.sendStatus(200);
     } else {
-        res.status(500);
+        res.sendStatus(500);
     }
 });
 
@@ -41,7 +41,7 @@ WebhooksRouter.post('/jira/issue-deleted', async (req, res) => {
     if (updatedData) {
         res.sendStatus(200);
     } else {
-        res.status(500);
+        res.sendStatus(500);
     }
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
-import app from './app';
+import { App } from './app';
 
 const port = 3000;
 
-app.listen(port, () => {
+App.listen(port, () => {
     console.log(`Example app listening on port ${port}`);
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
-import { App } from './app';
+import { app } from './app';
 
 const port = 3000;
 
-App.listen(port, () => {
+app.listen(port, () => {
     console.log(`Example app listening on port ${port}`);
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -29,4 +29,4 @@ export type DecodedJwtTokenType = {
 
 export const decodeJwtToken = (encodedToken: string): DecodedJwtTokenType => {
     return jwt_decode(encodedToken);
-}
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+import jwt_decode from 'jwt-decode';
 
 /**
  * This baseUrl is pulled from the ngrok tunnel API,
@@ -15,4 +16,17 @@ export const baseUrl = async (): Promise<string> => {
     const tunnel = data.tunnels.filter(tunnel => tunnel.proto === "https");
 
     return tunnel[0].public_url;
+}
+
+export type DecodedJwtTokenType = {
+    sub: string;
+    qsh: string;
+    iss: string;
+    context: any;
+    exp: number;
+    iat: number;
+};
+
+export const decodeJwtToken = (encodedToken: string): DecodedJwtTokenType => {
+    return jwt_decode(encodedToken);
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,4 @@
-import jwt_decode from 'jwt-decode';
-import {decodeAsymmetric, getAlgorithm, getKeyId} from "atlassian-jwt";
+import { decodeSymmetric, getAlgorithm } from 'atlassian-jwt';
 
 /**
  * This baseUrl is pulled from the ngrok tunnel API,
@@ -19,37 +18,10 @@ export const baseUrl = async (): Promise<string> => {
     return tunnel[0].public_url;
 }
 
-export type DecodedJwtTokenType = {
-    sub: string;
-    qsh: string;
-    iss: string;
-    context: any;
-    exp: number;
-    iat: number;
-};
 
-export const decodeJwtToken = (encodedToken: string): DecodedJwtTokenType => {
-    return jwt_decode(encodedToken);
-};
-export const decodeAtlassianJwtToken = async (token) => {
-    console.log("Key Id", getKeyId(token), getAlgorithm(token));
-    const publicKey = await queryAtlassianConnectPublicKey(getKeyId(token));
-    console.log("publicKey", publicKey);
-    return decodeAsymmetric(
-        token,
-        publicKey,
-        getAlgorithm(token),
-        false
-    );
-};
-
-const queryAtlassianConnectPublicKey = async (keyId: string): Promise<string> => {
-    const keyServerUrl = "https://connect-install-keys.atlassian.com";
-
-    const response = await fetch(`${keyServerUrl}/${keyId}`);
-    if (response.status !== 200) {
-        throw new Error(`Unable to get public key for keyId ${keyId}`);
-    }
-    const result = await response.json();
-    return result.data;
+/**
+ * Decoding the JWT token passed from Jira
+ */
+export const decodeJwtToken = (encodedToken: string, sharedSecret: string) => {
+    return decodeSymmetric(encodedToken, sharedSecret, getAlgorithm(encodedToken));
 };

--- a/src/views/config.mst
+++ b/src/views/config.mst
@@ -9,7 +9,7 @@
 <body>
 <br/>
 <br/>
-<a class="aui-button" href="/">Home</a>
+<button class="aui-button" id="homePage">Home</button>
 <br/>
 <br/>
 <h3>Atlassian Connect Config:</h3>
@@ -20,4 +20,13 @@
 </body>
 <!-- This script is needed for all the views in the connect app -->
 <script src="https://connect-cdn.atl-paas.net/all.js" async></script>
+<script>
+    /**
+     *  Page navigation is handled by AP.navigator
+     *  source: https://developer.atlassian.com/cloud/jira/software/jsapi/navigator/
+     */
+    document.getElementById('homePage').addEventListener('click', () => {
+        AP.navigator.go('addonmodule', { moduleKey: 'acn-index' });
+    });
+</script>
 </html>

--- a/src/views/index.mst
+++ b/src/views/index.mst
@@ -22,10 +22,10 @@
     Check out the links:
     <ul>
         <li>
-            <a href="/config">Atlassian Connect App config</a>
+            <a class="aui-button aui-button-link" id="configPage">Atlassian Connect App config</a>
         </li>
         <li>
-            <a href="/webhooks">Jira Webhook Logs</a>
+            <a class="aui-button aui-button-link" id="webhookLogsPage">Jira Webhook Logs</a>
         </li>
     </ul>
 </div>
@@ -34,4 +34,16 @@
 </body>
 <!-- This script is needed for all the views in the connect app -->
 <script src="https://connect-cdn.atl-paas.net/all.js" async></script>
+<script>
+    /**
+     *  Page navigation is handled by AP.navigator
+     *  source: https://developer.atlassian.com/cloud/jira/software/jsapi/navigator/
+     */
+    document.getElementById('configPage').addEventListener('click', () => {
+        AP.navigator.go('addonmodule', { moduleKey: 'acn-config' });
+    });
+    document.getElementById('webhookLogsPage').addEventListener('click', () => {
+        AP.navigator.go('addonmodule', { moduleKey: 'acn-logs-webhooks' });
+    });
+</script>
 </html>

--- a/src/views/webhooksLogs.mst
+++ b/src/views/webhooksLogs.mst
@@ -9,13 +9,13 @@
 <body>
 <br/>
 <br/>
-<a class="aui-button" href="/">Home</a>
+<button class="aui-button" id="homePage">Home</button>
 <br/>
 <br/>
 <div class="flexed">
     <div>Checkout the logs:</div>
     <div>
-        <a class="aui-button" href="/webhooks">
+        <a class="aui-button" id="refresh">
             <span class="aui-icon aui-icon-small aui-iconfont-refresh">Refresh</span>
             <span>Refresh</span>
         </a>
@@ -32,4 +32,16 @@
 </body>
 <!-- This script is needed for all the views in the connect app -->
 <script src="https://connect-cdn.atl-paas.net/all.js" async></script>
+<script>
+    /**
+     *  Page navigation is handled by AP.navigator
+     *  source: https://developer.atlassian.com/cloud/jira/software/jsapi/navigator/
+     */
+    document.getElementById('homePage').addEventListener('click', () => {
+        AP.navigator.go('addonmodule', { moduleKey: 'acn-index' });
+    });
+    document.getElementById('refresh').addEventListener('click', () => {
+        AP.navigator.reload();
+    });
+</script>
 </html>

--- a/src/views/webhooksLogs.mst
+++ b/src/views/webhooksLogs.mst
@@ -26,6 +26,9 @@
     {{#logs}}
         <pre>{{.}}</pre>
     {{/logs}}
+    {{^logs}}
+        <pre>No logs yet!</pre>
+    {{/logs}}
 </div>
 <br/>
 <br/>

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,11 +576,6 @@ jsuri@^1.3.1:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/jsuri/-/jsuri-1.3.1.tgz#cd93fc6a87b255142cb7b0f479f00517ab9395ed"
   integrity sha512-LLdAeqOf88/X0hylAI7oSir6QUsz/8kOW0FcJzzu/SJRfORA/oPHycAOthkNp7eLPlTAbqVDFbqNRHkRVzEA3g==
 
-jwt-decode@^3.1.2:
-  version "3.1.2"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
-  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
-
 lie@3.1.1:
   version "3.1.1"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,10 +270,23 @@ content-type@~1.0.4:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
+cookie-parser@^1.4.6:
+  version "1.4.6"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/cookie-parser/-/cookie-parser-1.4.6.tgz#3ac3a7d35a7a03bbc7e365073a26074824214594"
+  integrity sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==
+  dependencies:
+    cookie "0.4.1"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
+
+cookie@0.4.1:
+  version "0.4.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 cookie@0.5.0:
   version "0.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,23 +278,10 @@ content-type@~1.0.4:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
-cookie-parser@^1.4.6:
-  version "1.4.6"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/cookie-parser/-/cookie-parser-1.4.6.tgz#3ac3a7d35a7a03bbc7e365073a26074824214594"
-  integrity sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==
-  dependencies:
-    cookie "0.4.1"
-    cookie-signature "1.0.6"
-
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
-
-cookie@0.4.1:
-  version "0.4.1"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
-  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 cookie@0.5.0:
   version "0.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,6 +563,11 @@ is-number@^7.0.0:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 lie@3.1.1:
   version "3.1.1"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,6 +170,14 @@ async@~3.2.0:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
+atlassian-jwt@^2.0.2:
+  version "2.0.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/atlassian-jwt/-/atlassian-jwt-2.0.2.tgz#38ec00737b4b2761877b74d587f4a0ee198efd4f"
+  integrity sha512-HgG2p+gJeEqKREnPynEDy76UoShF01jTYMSe0NlRL2rEqXBNDzJiiCyUP7P2cbxcRmI4OC8g40zJjqftFNJ/4A==
+  dependencies:
+    jsuri "^1.3.1"
+    lodash "^4.17.21"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -563,6 +571,11 @@ is-number@^7.0.0:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+jsuri@^1.3.1:
+  version "1.3.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/jsuri/-/jsuri-1.3.1.tgz#cd93fc6a87b255142cb7b0f479f00517ab9395ed"
+  integrity sha512-LLdAeqOf88/X0hylAI7oSir6QUsz/8kOW0FcJzzu/SJRfORA/oPHycAOthkNp7eLPlTAbqVDFbqNRHkRVzEA3g==
+
 jwt-decode@^3.1.2:
   version "3.1.2"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
@@ -581,6 +594,11 @@ localforage@^1.3.0:
   integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
   dependencies:
     lie "3.1.1"
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lru-cache@~5.1.1:
   version "5.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,6 +27,20 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@seald-io/binary-search-tree@^1.0.2":
+  version "1.0.3"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@seald-io/binary-search-tree/-/binary-search-tree-1.0.3.tgz#165a9a456eaa30d15885b25db83861bcce2c6a74"
+  integrity sha512-qv3jnwoakeax2razYaMsGI/luWdliBLHTdC6jU55hQt1hcFqzauH/HsBollQ7IR4ySTtYhT+xyHoijpA16C+tA==
+
+"@seald-io/nedb@^3.1.0":
+  version "3.1.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@seald-io/nedb/-/nedb-3.1.0.tgz#6105345a18596f6f9d69f46d7f572efdae32af8e"
+  integrity sha512-5G0hCQGJjOelOutvW1l4VD581XMhTPxpj1BUaCWTEM2MPXR9TzIr0MKMnEjnTA5nEKfujPyvVW7iF3etm1/gKQ==
+  dependencies:
+    "@seald-io/binary-search-tree" "^1.0.2"
+    localforage "^1.9.0"
+    util "^0.12.4"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
@@ -160,11 +174,6 @@ array-flatten@1.1.1:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
 
-async@0.2.10:
-  version "0.2.10"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
-  integrity sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==
-
 async@~3.2.0:
   version "3.2.4"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
@@ -178,6 +187,11 @@ atlassian-jwt@^2.0.2:
     jsuri "^1.3.1"
     lodash "^4.17.21"
 
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -187,13 +201,6 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
-
-binary-search-tree@0.2.5:
-  version "0.2.5"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/binary-search-tree/-/binary-search-tree-0.2.5.tgz#7dbb3b210fdca082450dad2334c304af39bdc784"
-  integrity sha512-CvNVKS6iXagL1uGwLagSXz1hzSMezxOuGnFi5FHGKqaTO3nPPWrAbyALUzK640j+xOTVm7lzD9YP8W1f/gvUdw==
-  dependencies:
-    underscore "~1.4.4"
 
 body-parser@1.20.1:
   version "1.20.1"
@@ -238,7 +245,7 @@ bytes@3.1.2:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-call-bind@^1.0.0:
+call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
   integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
@@ -411,6 +418,13 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 forwarded@0.2.0:
   version "0.2.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
@@ -436,7 +450,7 @@ function-bind@^1.1.1:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-get-intrinsic@^1.0.2:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.3:
   version "1.2.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
   integrity sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==
@@ -464,15 +478,29 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
-has-symbols@^1.0.3:
+has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has@^1.0.3:
   version "1.0.3"
@@ -517,7 +545,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -527,12 +555,25 @@ ipaddr.js@1.9.1:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
+is-arguments@^1.0.4:
+  version "1.1.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-callable@^1.1.3:
+  version "1.2.7"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-core-module@^2.9.0:
   version "2.11.0"
@@ -546,6 +587,13 @@ is-extglob@^2.1.1:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
+is-generator-function@^1.0.7:
+  version "1.0.10"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
@@ -557,6 +605,17 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-typed-array@^1.1.10, is-typed-array@^1.1.3:
+  version "1.1.10"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
+  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
 
 jsuri@^1.3.1:
   version "1.3.1"
@@ -570,7 +629,7 @@ lie@3.1.1:
   dependencies:
     immediate "~3.0.5"
 
-localforage@^1.3.0:
+localforage@^1.9.0:
   version "1.10.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
   integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
@@ -643,13 +702,6 @@ mkdirp@^1.0.4:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@~0.5.1:
-  version "0.5.6"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
-  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
-  dependencies:
-    minimist "^1.2.6"
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -674,16 +726,12 @@ mustache@^4.2.0:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
   integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
-nedb@^1.8.0:
-  version "1.8.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/nedb/-/nedb-1.8.0.tgz#0e3502cd82c004d5355a43c9e55577bd7bd91d88"
-  integrity sha512-ip7BJdyb5m+86ZbSb4y10FCCW9g35+U8bDRrZlAfCI6m4dKwEsQ5M52grcDcVK4Vm/vnPlDLywkyo3GliEkb5A==
+nedb-promises@^6.2.1:
+  version "6.2.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/nedb-promises/-/nedb-promises-6.2.1.tgz#5280a32fb9c9996e77a93195f595860f88e8454a"
+  integrity sha512-vurL/Hfsk37mbsjYTu+MKnMUytboKBjWWEA0N35ArCBMdDW5x2BAE7Xny4qnlpR90ZuaI8gdWbbGQ2ZoJSp/FQ==
   dependencies:
-    async "0.2.10"
-    binary-search-tree "0.2.5"
-    localforage "^1.3.0"
-    mkdirp "~0.5.1"
-    underscore "~1.4.4"
+    "@seald-io/nedb" "^3.1.0"
 
 negotiator@0.6.3:
   version "0.6.3"
@@ -1022,15 +1070,21 @@ undefsafe@^2.0.5:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
-underscore@~1.4.4:
-  version "1.4.4"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
-  integrity sha512-ZqGrAgaqqZM7LGRzNjLnw5elevWb5M8LEoDMadxIW3OWbcv72wMMgKdwOKpd5Fqxe8choLD8HN3iSj3TUh/giQ==
-
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
+
+util@^0.12.4:
+  version "0.12.5"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
+  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    which-typed-array "^1.1.2"
 
 utils-merge@1.0.1:
   version "1.0.1"
@@ -1046,6 +1100,18 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+which-typed-array@^1.1.2:
+  version "1.1.9"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
+  integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.10"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
- Added `clientKey` for TenantType and inserted `clientKey` after installation.
- Added a middleware which uses `cookies` for storing the jwt token from Jira side for identifying the Jira instance.
- Used `jwt-decode` to decode the jwt token from Jira and map the corresponding host to display the corresponding logs.

**Video**
https://www.loom.com/share/94a11c7198d54ed9afc48820cf039d98